### PR TITLE
fix: delete initiative performance log and audit log fix

### DIFF
--- a/src/main/java/it/gov/pagopa/initiative/service/InitiativeServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/initiative/service/InitiativeServiceImpl.java
@@ -655,7 +655,7 @@ public class InitiativeServiceImpl extends InitiativeServiceRoot implements Init
         }
 
         initiativeRepository.deleteById(initiativeId);
-        log.info("[DELETE INITIATIVE] Deleted initiative with initiativeId {}", initiativeId);
+        log.info("[DELETE_INITIATIVE] Deleted initiative {} from collection: initiative", initiativeId);
         auditUtilities.logDeletedInitiative(initiativeId);
 
         performanceLog(startTime, DELETE_INITIATIVE_SERVICE);

--- a/src/main/java/it/gov/pagopa/initiative/utils/AuditUtilities.java
+++ b/src/main/java/it/gov/pagopa/initiative/utils/AuditUtilities.java
@@ -102,7 +102,7 @@ public class AuditUtilities {
   public void logDeletedInitiative(String initiativeId){
     logAuditString(
             AuditUtilities.CEF_PATTERN_INITIATIVE_ID,
-            "Deleted initiative:",  initiativeId
+            "Initiative deleted",  initiativeId
     );
   }
 

--- a/src/test/java/it/gov/pagopa/initiative/utils/AuditUtilitiesTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/utils/AuditUtilitiesTest.java
@@ -216,7 +216,7 @@ class AuditUtilitiesTest {
         auditUtilities.logDeletedInitiative(INITIATIVE_ID);
 
         Assertions.assertEquals(
-                ("CEF:0|PagoPa|IDPAY|1.0|7|User interaction|2| event=Initiative dstip=%s msg=Deleted initiative:" +
+                ("CEF:0|PagoPa|IDPAY|1.0|7|User interaction|2| event=Initiative dstip=%s msg=Initiative deleted" +
                         " cs1Label=initiativeId cs1=%s")
                         .formatted(
                                 AuditUtilities.SRCIP,


### PR DESCRIPTION
**Description**

The purpose of this PR is to allign performance logs and audit logs for the initiative delete.

**List of changes**

-  Modify performance log and info log
-  Modify audit logs

**Motivation and context**

**How has this been tested?**

- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [X] Api Tests
- [ ] Load Tests  

**Types of changes**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

**Checklist:**

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.