### PR TITLE
fix: Added check for initiative endDate in updateInitiativePublishedStatus

### DIFF
--- a/src/main/java/it/gov/pagopa/initiative/constants/InitiativeConstants.java
+++ b/src/main/java/it/gov/pagopa/initiative/constants/InitiativeConstants.java
@@ -94,7 +94,7 @@ public class InitiativeConstants {
             public static final String REWARD_TYPE = "REWARD INVALID";
             public static final String REFUND_RULE_INVALID = "REFUND RULE INVALID";
             public static final String ISEE_TYPES_NOT_VALID = "Automated criteria not valid. ISEE typology is missing.";
-            public static final String INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED = "The initiative [%s] cannot be published because the end date [%s] has passed";
+            public static final String INITIATIVE_BY_INITIATIVE_ID_UNPROCESSABLE_FOR_NOT_VALID_END_DATE = "Initiative [%s] unprocessable because the end date [%s] has passed";
         }
         public static final class Publish {
             public static final String PUBLISH_CODE = BASE_CODE + ".published";

--- a/src/main/java/it/gov/pagopa/initiative/constants/InitiativeConstants.java
+++ b/src/main/java/it/gov/pagopa/initiative/constants/InitiativeConstants.java
@@ -99,7 +99,9 @@ public class InitiativeConstants {
             public static final String PUBLISH_CODE = BASE_CODE + ".published";
             public static final class BadRequest { //400
                 public static final String CODE = PUBLISH_CODE + ".bad.request";
+                public static final String CODE_INITIATIVE_CANNOT_BE_PUBLISHED = "INITIATIVE_CANNOT_BE_PUBLISHED";
                 public static final String INTEGRATION_FAILED = "Something gone wrong while notify Initiative for publishing";
+                public static final String INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED = "The initiative [%s] cannot be published because the end date [%s] has passed";
             }
             public static final class InternalServerError{
                 public static final String CODE = PUBLISH_CODE + ".internal.server.error";

--- a/src/main/java/it/gov/pagopa/initiative/constants/InitiativeConstants.java
+++ b/src/main/java/it/gov/pagopa/initiative/constants/InitiativeConstants.java
@@ -94,14 +94,13 @@ public class InitiativeConstants {
             public static final String REWARD_TYPE = "REWARD INVALID";
             public static final String REFUND_RULE_INVALID = "REFUND RULE INVALID";
             public static final String ISEE_TYPES_NOT_VALID = "Automated criteria not valid. ISEE typology is missing.";
+            public static final String INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED = "The initiative [%s] cannot be published because the end date [%s] has passed";
         }
         public static final class Publish {
             public static final String PUBLISH_CODE = BASE_CODE + ".published";
             public static final class BadRequest { //400
                 public static final String CODE = PUBLISH_CODE + ".bad.request";
-                public static final String CODE_INITIATIVE_CANNOT_BE_PUBLISHED = "INITIATIVE_CANNOT_BE_PUBLISHED";
                 public static final String INTEGRATION_FAILED = "Something gone wrong while notify Initiative for publishing";
-                public static final String INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED = "The initiative [%s] cannot be published because the end date [%s] has passed";
             }
             public static final class InternalServerError{
                 public static final String CODE = PUBLISH_CODE + ".internal.server.error";

--- a/src/main/java/it/gov/pagopa/initiative/controller/InitiativeApiController.java
+++ b/src/main/java/it/gov/pagopa/initiative/controller/InitiativeApiController.java
@@ -1,6 +1,5 @@
 package it.gov.pagopa.initiative.controller;
 
-import it.gov.pagopa.common.web.exception.ClientExceptionWithBody;
 import it.gov.pagopa.initiative.constants.InitiativeConstants;
 import it.gov.pagopa.initiative.dto.*;
 import it.gov.pagopa.initiative.dto.io.service.KeysDTO;
@@ -23,15 +22,12 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Locale;
 
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Email.SUBJECT_CHANGE_STATE;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Email.TEMPLATE_NAME_EMAIL_INITIATIVE_STATUS;
-import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.Publish.BadRequest.INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED;
-import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.Publish.BadRequest.CODE_INITIATIVE_CANNOT_BE_PUBLISHED;
 
 @RestController
 @Slf4j
@@ -248,15 +244,6 @@ public class InitiativeApiController implements InitiativeApi {
         log.debug("Validating current Status");
         initiativeService.isInitiativeAllowedToBeNextStatusThenThrows(initiative, InitiativeConstants.Status.PUBLISHED, role);
         log.debug("Current Status validated");
-
-        //validation end date
-        log.debug("Validating initiative end date");
-        LocalDate initiativeEndDate = initiative.getGeneral().getEndDate();
-        if(LocalDate.now().isAfter(initiativeEndDate)){
-            throw new ClientExceptionWithBody(HttpStatus.BAD_REQUEST,
-                    CODE_INITIATIVE_CANNOT_BE_PUBLISHED,
-                    String.format(INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED,initiativeId, initiativeEndDate));
-        }
 
         log.debug("Retrieve current state and save it as TEMP");
         String statusTemp = initiative.getStatus();

--- a/src/main/java/it/gov/pagopa/initiative/controller/InitiativeApiController.java
+++ b/src/main/java/it/gov/pagopa/initiative/controller/InitiativeApiController.java
@@ -244,6 +244,11 @@ public class InitiativeApiController implements InitiativeApi {
         Initiative initiative = this.initiativeService.getInitiative(organizationId, initiativeId, role);
         log.debug("Initiative retrieved");
 
+        //Validation for current Status
+        log.debug("Validating current Status");
+        initiativeService.isInitiativeAllowedToBeNextStatusThenThrows(initiative, InitiativeConstants.Status.PUBLISHED, role);
+        log.debug("Current Status validated");
+
         //validation end date
         log.debug("Validating initiative end date");
         LocalDate initiativeEndDate = initiative.getGeneral().getEndDate();
@@ -252,11 +257,6 @@ public class InitiativeApiController implements InitiativeApi {
                     CODE_INITIATIVE_CANNOT_BE_PUBLISHED,
                     String.format(INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED,initiativeId, initiativeEndDate));
         }
-
-        //Validation for current Status
-        log.debug("Validating current Status");
-        initiativeService.isInitiativeAllowedToBeNextStatusThenThrows(initiative, InitiativeConstants.Status.PUBLISHED, role);
-        log.debug("Current Status validated");
 
         log.debug("Retrieve current state and save it as TEMP");
         String statusTemp = initiative.getStatus();

--- a/src/main/java/it/gov/pagopa/initiative/service/InitiativeServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/initiative/service/InitiativeServiceImpl.java
@@ -2,7 +2,6 @@ package it.gov.pagopa.initiative.service;
 
 import com.google.common.io.Files;
 import feign.FeignException;
-import it.gov.pagopa.common.web.exception.ClientExceptionWithBody;
 import it.gov.pagopa.initiative.connector.decrypt.DecryptRestConnector;
 import it.gov.pagopa.initiative.connector.encrypt.EncryptRestConnector;
 import it.gov.pagopa.initiative.connector.file_storage.FileStorageConnector;

--- a/src/main/java/it/gov/pagopa/initiative/service/InitiativeServiceImpl.java
+++ b/src/main/java/it/gov/pagopa/initiative/service/InitiativeServiceImpl.java
@@ -47,7 +47,7 @@ import java.time.LocalDateTime;
 import java.util.*;
 
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Email.*;
-import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.BadRequest.INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED;
+import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.BadRequest.INITIATIVE_BY_INITIATIVE_ID_UNPROCESSABLE_FOR_NOT_VALID_END_DATE;
 
 
 @Service
@@ -387,7 +387,7 @@ public class InitiativeServiceImpl extends InitiativeServiceRoot implements Init
         if(LocalDate.now().isAfter(initiativeEndDate)){
             throw new InitiativeException(
                     InitiativeConstants.Exception.BadRequest.CODE,
-                    String.format(INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED, initiative.getInitiativeId(), initiativeEndDate),
+                    String.format(INITIATIVE_BY_INITIATIVE_ID_UNPROCESSABLE_FOR_NOT_VALID_END_DATE, initiative.getInitiativeId(), initiativeEndDate),
                     HttpStatus.BAD_REQUEST);
         }
     }

--- a/src/test/java/it/gov/pagopa/initiative/controller/InitiativeApiTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/controller/InitiativeApiTest.java
@@ -3,8 +3,6 @@ package it.gov.pagopa.initiative.controller;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.BadRequest.CODE;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.ErrorDtoDefaultMsg.ACCUMULATED_AMOUNT_TYPE;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.ErrorDtoDefaultMsg.SOMETHING_WRONG_WITH_THE_REFUND_TYPE;
-import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.Publish.BadRequest.INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED;
-import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.Publish.BadRequest.CODE_INITIATIVE_CANNOT_BE_PUBLISHED;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Role.ADMIN;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Role.PAGOPA_ADMIN;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1081,37 +1079,6 @@ class InitiativeApiTest {
         assertEquals(HttpStatus.BAD_REQUEST.value(), res.getResponse().getStatus());
         assertEquals(InitiativeConstants.Exception.Publish.BadRequest.CODE, error.getCode());
         assertTrue(error.getMessage().contains(InitiativeConstants.Exception.Publish.BadRequest.INTEGRATION_FAILED));
-    }
-
-
-    @Test
-    void updateInitiativepublishedStatus_badRequestInitiativeEnded() throws Exception {
-        InitiativeOrganizationInfoDTO initiativeOrganizationInfoDTO = createInitiativeOrganizationInfoDTO();
-
-        //create Dummy Initiative
-        Initiative step5Initiative = createStep5Initiative();
-        step5Initiative.getGeneral().setEndDate(LocalDate.now().minusDays(1));
-
-        // When
-        // With this instruction, I instruct the service (via Mockito's when) to always return the DummyInitiative to me anytime I call the same service's function
-        when(initiativeService.getInitiative(ORGANIZATION_ID, INITIATIVE_ID, ROLE)).thenReturn(step5Initiative);
-
-        doNothing().when(initiativeService).isInitiativeAllowedToBeNextStatusThenThrows(step5Initiative, InitiativeConstants.Status.PUBLISHED, ROLE);
-
-        MvcResult res =
-                mvc.perform(MockMvcRequestBuilders.put(BASE_URL + String.format(PUT_INITIATIVE_TO_PUBLISHED_STATUS_URL, ORGANIZATION_ID, INITIATIVE_ID, ROLE))
-                                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                                .content(objectMapper.writeValueAsString(initiativeOrganizationInfoDTO))
-                                .accept(MediaType.APPLICATION_JSON))
-                        .andExpect(MockMvcResultMatchers.status().isBadRequest())
-                        .andDo(print())
-                        .andReturn();
-
-        ErrorDTO error = objectMapper.readValue(res.getResponse().getContentAsString(), ErrorDTO.class);
-        assertEquals(HttpStatus.BAD_REQUEST.value(), res.getResponse().getStatus());
-        assertEquals(CODE_INITIATIVE_CANNOT_BE_PUBLISHED, error.getCode());
-        assertEquals(String.format(INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED,step5Initiative.getInitiativeId(), step5Initiative.getGeneral().getEndDate()),
-                error.getMessage());
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/initiative/controller/InitiativeApiTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/controller/InitiativeApiTest.java
@@ -1096,6 +1096,8 @@ class InitiativeApiTest {
         // With this instruction, I instruct the service (via Mockito's when) to always return the DummyInitiative to me anytime I call the same service's function
         when(initiativeService.getInitiative(ORGANIZATION_ID, INITIATIVE_ID, ROLE)).thenReturn(step5Initiative);
 
+        doNothing().when(initiativeService).isInitiativeAllowedToBeNextStatusThenThrows(step5Initiative, InitiativeConstants.Status.PUBLISHED, ROLE);
+
         MvcResult res =
                 mvc.perform(MockMvcRequestBuilders.put(BASE_URL + String.format(PUT_INITIATIVE_TO_PUBLISHED_STATUS_URL, ORGANIZATION_ID, INITIATIVE_ID, ROLE))
                                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/it/gov/pagopa/initiative/controller/InitiativeApiTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/controller/InitiativeApiTest.java
@@ -3,6 +3,8 @@ package it.gov.pagopa.initiative.controller;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.BadRequest.CODE;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.ErrorDtoDefaultMsg.ACCUMULATED_AMOUNT_TYPE;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.ErrorDtoDefaultMsg.SOMETHING_WRONG_WITH_THE_REFUND_TYPE;
+import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.Publish.BadRequest.INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED;
+import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.Publish.BadRequest.CODE_INITIATIVE_CANNOT_BE_PUBLISHED;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Role.ADMIN;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Role.PAGOPA_ADMIN;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -75,7 +77,6 @@ import it.gov.pagopa.initiative.model.rule.refund.AccumulatedAmount;
 import it.gov.pagopa.initiative.model.rule.refund.AdditionalInfo;
 import it.gov.pagopa.initiative.model.rule.refund.InitiativeRefundRule;
 import it.gov.pagopa.initiative.model.rule.refund.TimeParameter;
-import it.gov.pagopa.initiative.service.AESTokenServiceImpl;
 import it.gov.pagopa.initiative.service.InitiativeService;
 import it.gov.pagopa.initiative.service.OrganizationService;
 import java.io.ByteArrayInputStream;
@@ -1080,6 +1081,35 @@ class InitiativeApiTest {
         assertEquals(HttpStatus.BAD_REQUEST.value(), res.getResponse().getStatus());
         assertEquals(InitiativeConstants.Exception.Publish.BadRequest.CODE, error.getCode());
         assertTrue(error.getMessage().contains(InitiativeConstants.Exception.Publish.BadRequest.INTEGRATION_FAILED));
+    }
+
+
+    @Test
+    void updateInitiativepublishedStatus_badRequestInitiativeEnded() throws Exception {
+        InitiativeOrganizationInfoDTO initiativeOrganizationInfoDTO = createInitiativeOrganizationInfoDTO();
+
+        //create Dummy Initiative
+        Initiative step5Initiative = createStep5Initiative();
+        step5Initiative.getGeneral().setEndDate(LocalDate.now().minusDays(1));
+
+        // When
+        // With this instruction, I instruct the service (via Mockito's when) to always return the DummyInitiative to me anytime I call the same service's function
+        when(initiativeService.getInitiative(ORGANIZATION_ID, INITIATIVE_ID, ROLE)).thenReturn(step5Initiative);
+
+        MvcResult res =
+                mvc.perform(MockMvcRequestBuilders.put(BASE_URL + String.format(PUT_INITIATIVE_TO_PUBLISHED_STATUS_URL, ORGANIZATION_ID, INITIATIVE_ID, ROLE))
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(objectMapper.writeValueAsString(initiativeOrganizationInfoDTO))
+                                .accept(MediaType.APPLICATION_JSON))
+                        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                        .andDo(print())
+                        .andReturn();
+
+        ErrorDTO error = objectMapper.readValue(res.getResponse().getContentAsString(), ErrorDTO.class);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), res.getResponse().getStatus());
+        assertEquals(CODE_INITIATIVE_CANNOT_BE_PUBLISHED, error.getCode());
+        assertEquals(String.format(INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED,step5Initiative.getInitiativeId(), step5Initiative.getGeneral().getEndDate()),
+                error.getMessage());
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/initiative/service/InitiativeServiceTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/service/InitiativeServiceTest.java
@@ -61,6 +61,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
 
+import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.BadRequest.INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Role.ADMIN;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Role.PAGOPA_ADMIN;
 import static org.junit.jupiter.api.Assertions.*;
@@ -1186,10 +1187,42 @@ class InitiativeServiceTest {
         Initiative initiative = createStep5Initiative();
         initiative.setStatus(InitiativeConstants.Status.APPROVED);
 
+        LocalDate localDateNow = LocalDate.now();
+        InitiativeGeneral initiativeGeneral = InitiativeGeneral.builder()
+                .startDate(localDateNow.minusDays(5))
+                .endDate(localDateNow)
+                .build();
+        initiative.setGeneral(initiativeGeneral);
+
         //Try to call the Real Service
         //Prepare Executable with invocation of the method on your system under test
         Executable executable = () -> initiativeService.isInitiativeAllowedToBeNextStatusThenThrows(initiative, InitiativeConstants.Status.PUBLISHED, ROLE);
         Assertions.assertDoesNotThrow(executable);
+    }
+
+    @Test
+    void givenInitiativeAPPROVEDandNextStatusPUBLISHED_whenInitiativeIsAllowedToBeNextStatus_thenKoEndDate() {
+        //Instruct Initiative to have a status Valid (APPROVED)
+        Initiative initiative = createStep5Initiative();
+        initiative.setStatus(InitiativeConstants.Status.APPROVED);
+
+        LocalDate localDateNow = LocalDate.now();
+        InitiativeGeneral initiativeGeneral = InitiativeGeneral.builder()
+                .startDate(localDateNow.minusDays(5))
+                .endDate(localDateNow.minusDays(3))
+                .build();
+        initiative.setGeneral(initiativeGeneral);
+
+        //Try to call the Real Service
+        //Prepare Executable with invocation of the method on your system under test
+        InitiativeException initiativeExceptionResult = assertThrows(InitiativeException.class,
+                () -> initiativeService.isInitiativeAllowedToBeNextStatusThenThrows(initiative, Status.PUBLISHED, ROLE));
+
+        assertEquals(InitiativeConstants.Exception.BadRequest.CODE, initiativeExceptionResult.getCode());
+        assertEquals(String.format(INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED, initiative.getInitiativeId(), initiative.getGeneral().getEndDate()), initiativeExceptionResult.getMessage());
+        assertEquals(HttpStatus.BAD_REQUEST, initiativeExceptionResult.getHttpStatus());
+
+
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/initiative/service/InitiativeServiceTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/service/InitiativeServiceTest.java
@@ -61,7 +61,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
 
-import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.BadRequest.INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED;
+import static it.gov.pagopa.initiative.constants.InitiativeConstants.Exception.BadRequest.INITIATIVE_BY_INITIATIVE_ID_UNPROCESSABLE_FOR_NOT_VALID_END_DATE;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Role.ADMIN;
 import static it.gov.pagopa.initiative.constants.InitiativeConstants.Role.PAGOPA_ADMIN;
 import static org.junit.jupiter.api.Assertions.*;
@@ -1219,7 +1219,7 @@ class InitiativeServiceTest {
                 () -> initiativeService.isInitiativeAllowedToBeNextStatusThenThrows(initiative, Status.PUBLISHED, ROLE));
 
         assertEquals(InitiativeConstants.Exception.BadRequest.CODE, initiativeExceptionResult.getCode());
-        assertEquals(String.format(INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED, initiative.getInitiativeId(), initiative.getGeneral().getEndDate()), initiativeExceptionResult.getMessage());
+        assertEquals(String.format(INITIATIVE_BY_INITIATIVE_ID_UNPROCESSABLE_FOR_NOT_VALID_END_DATE, initiative.getInitiativeId(), initiative.getGeneral().getEndDate()), initiativeExceptionResult.getMessage());
         assertEquals(HttpStatus.BAD_REQUEST, initiativeExceptionResult.getHttpStatus());
     }
 

--- a/src/test/java/it/gov/pagopa/initiative/service/InitiativeServiceTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/service/InitiativeServiceTest.java
@@ -1221,8 +1221,6 @@ class InitiativeServiceTest {
         assertEquals(InitiativeConstants.Exception.BadRequest.CODE, initiativeExceptionResult.getCode());
         assertEquals(String.format(INITIATIVE_CANNOT_BE_PUBLISHED_BC_FINISHED, initiative.getInitiativeId(), initiative.getGeneral().getEndDate()), initiativeExceptionResult.getMessage());
         assertEquals(HttpStatus.BAD_REQUEST, initiativeExceptionResult.getHttpStatus());
-
-
     }
 
     @Test


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
- Added check initiative endDate in updatePublished API

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Do not allow the publication of the initiative after the endDate.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
    - [x] Unit
    - [x] Integration (Narrow)
- Post-Deploy Test
    - [ ] Isolated Microservice
    - [ ] Broader Integration
    - [ ] Acceptance
    - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.