### PR TITLE
fix: correct _type field typo after Java 25 upgrade

### DIFF
--- a/src/main/java/it/gov/pagopa/initiative/mapper/InitiativeDTOsToModelMapper.java
+++ b/src/main/java/it/gov/pagopa/initiative/mapper/InitiativeDTOsToModelMapper.java
@@ -132,28 +132,28 @@ public class InitiativeDTOsToModelMapper {
                 .stream().map(dto -> {
                     if (dto instanceof SelfCriteriaBoolDTO selfCriteriaBoolDTOInput) {
                         return SelfCriteriaBool.builder()
-                                ._type(it.gov.pagopa.initiative.model.TypeBoolEnum.valueOf(selfCriteriaBoolDTOInput.getType().name()))
+                                .type(it.gov.pagopa.initiative.model.TypeBoolEnum.valueOf(selfCriteriaBoolDTOInput.getType().name()))
                                 .code(selfCriteriaBoolDTOInput.getCode())
                                 .description(selfCriteriaBoolDTOInput.getDescription())
                                 .value(selfCriteriaBoolDTOInput.getValue())
                                 .build();
                     } else if (dto instanceof SelfCriteriaMultiDTO selfCriteriaMultiDTO) {
                         return SelfCriteriaMulti.builder()
-                                ._type(TypeMultiEnum.valueOf(selfCriteriaMultiDTO.getType().name()))
+                                .type(TypeMultiEnum.valueOf(selfCriteriaMultiDTO.getType().name()))
                                 .code(selfCriteriaMultiDTO.getCode())
                                 .description(selfCriteriaMultiDTO.getDescription())
                                 .value(selfCriteriaMultiDTO.getValue())
                                 .build();
                     } else if (dto instanceof SelfCriteriaTextDTO selfCriteriaTextDTO) {
                         return SelfCriteriaText.builder()
-                                ._type(TypeTextEnum.valueOf(selfCriteriaTextDTO.getType().name()))
+                                .type(TypeTextEnum.valueOf(selfCriteriaTextDTO.getType().name()))
                                 .code(selfCriteriaTextDTO.getCode())
                                 .description(selfCriteriaTextDTO.getDescription())
                                 .value(selfCriteriaTextDTO.getValue())
                                 .build();
                     }else if (dto instanceof SelfCriteriaMultiConsentDTO selfCriteriaMultiConsentDTO) {
                         return SelfCriteriaMultiConsent.builder()
-                                ._type(TypeMultiConsentEnum.valueOf(selfCriteriaMultiConsentDTO.getType().name()))
+                                .type(TypeMultiConsentEnum.valueOf(selfCriteriaMultiConsentDTO.getType().name()))
                                 .code(selfCriteriaMultiConsentDTO.getCode())
                                 .description(selfCriteriaMultiConsentDTO.getDescription())
                                 .subDescription(selfCriteriaMultiConsentDTO.getSubDescription())

--- a/src/main/java/it/gov/pagopa/initiative/mapper/InitiativeModelToDTOMapper.java
+++ b/src/main/java/it/gov/pagopa/initiative/mapper/InitiativeModelToDTOMapper.java
@@ -231,7 +231,7 @@ public class InitiativeModelToDTOMapper {
                 .stream().map(x -> {
                     if (x instanceof SelfCriteriaBool selfCriteriaBool) {
                         return SelfCriteriaBoolDTO.builder()
-                                .type(it.gov.pagopa.initiative.dto.TypeBoolEnum.valueOf(selfCriteriaBool.get_type().name()))
+                                .type(it.gov.pagopa.initiative.dto.TypeBoolEnum.valueOf(selfCriteriaBool.getType().name()))
                                 .code(selfCriteriaBool.getCode())
                                 .description(selfCriteriaBool.getDescription())
                                 .subDescription(selfCriteriaBool.getSubDescription())
@@ -239,7 +239,7 @@ public class InitiativeModelToDTOMapper {
                                 .build();
                     } else if (x instanceof SelfCriteriaMulti selfCriteriaMulti) {
                         return SelfCriteriaMultiDTO.builder()
-                                .type(it.gov.pagopa.initiative.dto.TypeMultiEnum.valueOf(selfCriteriaMulti.get_type().name()))
+                                .type(it.gov.pagopa.initiative.dto.TypeMultiEnum.valueOf(selfCriteriaMulti.getType().name()))
                                 .code(selfCriteriaMulti.getCode())
                                 .description(selfCriteriaMulti.getDescription())
                                 .subDescription(selfCriteriaMulti.getSubDescription())
@@ -247,7 +247,7 @@ public class InitiativeModelToDTOMapper {
                                 .build();
                     } else if (x instanceof SelfCriteriaText selfCriteriaText) {
                         return SelfCriteriaTextDTO.builder()
-                                .type(TypeTextEnum.valueOf(selfCriteriaText.get_type().name()))
+                                .type(TypeTextEnum.valueOf(selfCriteriaText.getType().name()))
                                 .code(selfCriteriaText.getCode())
                                 .description(selfCriteriaText.getDescription())
                                 .subDescription(selfCriteriaText.getSubDescription())
@@ -255,7 +255,7 @@ public class InitiativeModelToDTOMapper {
                                 .build();
                     } else if (x instanceof SelfCriteriaMultiConsent selfCriteriaMultiConsent) {
                         return SelfCriteriaMultiConsentDTO.builder()
-                                .type(TypeMultiConsentEnum.valueOf(selfCriteriaMultiConsent.get_type().name()))
+                                .type(TypeMultiConsentEnum.valueOf(selfCriteriaMultiConsent.getType().name()))
                                 .code(selfCriteriaMultiConsent.getCode())
                                 .description(selfCriteriaMultiConsent.getDescription())
                                 .subDescription(selfCriteriaMultiConsent.getSubDescription())

--- a/src/main/java/it/gov/pagopa/initiative/model/SelfCriteriaBool.java
+++ b/src/main/java/it/gov/pagopa/initiative/model/SelfCriteriaBool.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.initiative.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 
@@ -10,7 +11,8 @@ import lombok.*;
 @Builder
 public class SelfCriteriaBool implements ISelfDeclarationCriteria {
 
-  private TypeBoolEnum _type;
+  @JsonProperty("_type")
+  private TypeBoolEnum type;
   private String description;
   private String subDescription;
   private Boolean value;

--- a/src/main/java/it/gov/pagopa/initiative/model/SelfCriteriaMulti.java
+++ b/src/main/java/it/gov/pagopa/initiative/model/SelfCriteriaMulti.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.initiative.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 import java.util.List;
@@ -12,7 +13,8 @@ import java.util.List;
 @Builder
 public class SelfCriteriaMulti implements ISelfDeclarationCriteria {
 
-  private TypeMultiEnum _type;
+  @JsonProperty("_type")
+  private TypeMultiEnum type;
   private String description;
   private String subDescription;
   private List<String> value;

--- a/src/main/java/it/gov/pagopa/initiative/model/SelfCriteriaMultiConsent.java
+++ b/src/main/java/it/gov/pagopa/initiative/model/SelfCriteriaMultiConsent.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.initiative.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import it.gov.pagopa.initiative.dto.SelfCriteriaMultiConsentValueDTO;
 import it.gov.pagopa.initiative.dto.TypeMultiConsentEnum;
 import lombok.*;
@@ -14,7 +15,8 @@ import java.util.List;
 @Builder
 public class SelfCriteriaMultiConsent implements ISelfDeclarationCriteria {
 
-  private TypeMultiConsentEnum _type;
+  @JsonProperty("_type")
+  private TypeMultiConsentEnum type;
   private String description;
   private String subDescription;
   private String thresholdCode;

--- a/src/main/java/it/gov/pagopa/initiative/model/SelfCriteriaText.java
+++ b/src/main/java/it/gov/pagopa/initiative/model/SelfCriteriaText.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.initiative.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 
 
@@ -10,7 +11,8 @@ import lombok.*;
 @Builder
 public class SelfCriteriaText implements ISelfDeclarationCriteria {
 
-  private TypeTextEnum _type;
+  @JsonProperty("_type")
+  private TypeTextEnum type;
   private String description;
   private String subDescription;
   private String value;

--- a/src/test/java/it/gov/pagopa/initiative/controller/InitiativeApiTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/controller/InitiativeApiTest.java
@@ -1457,12 +1457,12 @@ class InitiativeApiTest {
     private InitiativeBeneficiaryRule createInitiativeBeneficiaryRule() {
         InitiativeBeneficiaryRule initiativeBeneficiaryRule = new InitiativeBeneficiaryRule();
         SelfCriteriaBool selfCriteriaBool = new SelfCriteriaBool();
-        selfCriteriaBool.set_type(TypeBoolEnum.BOOLEAN);
+        selfCriteriaBool.setType(TypeBoolEnum.BOOLEAN);
         selfCriteriaBool.setCode("B001");
         selfCriteriaBool.setDescription("Desc_bool");
         selfCriteriaBool.setValue(true);
         SelfCriteriaMulti selfCriteriaMulti = new SelfCriteriaMulti();
-        selfCriteriaMulti.set_type(TypeMultiEnum.MULTI);
+        selfCriteriaMulti.setType(TypeMultiEnum.MULTI);
         selfCriteriaMulti.setCode("B001");
         selfCriteriaMulti.setDescription("Desc_Multi");
         List<String> values = new ArrayList<>();

--- a/src/test/java/it/gov/pagopa/initiative/mapper/InitiativeDTOsToModelMapperTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/mapper/InitiativeDTOsToModelMapperTest.java
@@ -462,12 +462,12 @@ class InitiativeDTOsToModelMapperTest {
     private InitiativeBeneficiaryRule createInitiativeBeneficiaryRule() {
         InitiativeBeneficiaryRule localInitiativeBeneficiaryRule = new InitiativeBeneficiaryRule();
         SelfCriteriaBool selfCriteriaBool = new SelfCriteriaBool();
-        selfCriteriaBool.set_type(TypeBoolEnum.BOOLEAN);
+        selfCriteriaBool.setType(TypeBoolEnum.BOOLEAN);
         selfCriteriaBool.setCode("B001");
         selfCriteriaBool.setDescription("Desc_bool");
         selfCriteriaBool.setValue(true);
         SelfCriteriaMulti selfCriteriaMulti = new SelfCriteriaMulti();
-        selfCriteriaMulti.set_type(TypeMultiEnum.MULTI);
+        selfCriteriaMulti.setType(TypeMultiEnum.MULTI);
         selfCriteriaMulti.setCode("B001");
         selfCriteriaMulti.setDescription("Desc_Multi");
         List<String> values = new ArrayList<>();
@@ -475,12 +475,12 @@ class InitiativeDTOsToModelMapperTest {
         values.add("valore2");
         selfCriteriaMulti.setValue(values);
         SelfCriteriaText selfCriteriaText = new SelfCriteriaText();
-        selfCriteriaText.set_type(TypeTextEnum.TEXT);
+        selfCriteriaText.setType(TypeTextEnum.TEXT);
         selfCriteriaText.setCode("T001");
         selfCriteriaText.setDescription("Text");
         selfCriteriaText.setValue("valore libero");
         SelfCriteriaMultiConsent selfCriteriaMultiConsent = new SelfCriteriaMultiConsent();
-        selfCriteriaMultiConsent.set_type(TypeMultiConsentEnum.MULTI_CONSENT);
+        selfCriteriaMultiConsent.setType(TypeMultiConsentEnum.MULTI_CONSENT);
         selfCriteriaMultiConsent.setCode("MC001");
         selfCriteriaMultiConsent.setDescription("Desc_Multi_Consent");
         selfCriteriaMultiConsent.setSubDescription("Sub_Desc_Multi_Consent");

--- a/src/test/java/it/gov/pagopa/initiative/mapper/InitiativeModelToDTOMapperTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/mapper/InitiativeModelToDTOMapperTest.java
@@ -769,12 +769,12 @@ class InitiativeModelToDTOMapperTest {
     private InitiativeBeneficiaryRule createInitiativeBeneficiaryRule() {
         InitiativeBeneficiaryRule localInitiativeBeneficiaryRule = new InitiativeBeneficiaryRule();
         SelfCriteriaBool selfCriteriaBool = new SelfCriteriaBool();
-        selfCriteriaBool.set_type(TypeBoolEnum.BOOLEAN);
+        selfCriteriaBool.setType(TypeBoolEnum.BOOLEAN);
         selfCriteriaBool.setCode("B001");
         selfCriteriaBool.setDescription("Desc_bool");
         selfCriteriaBool.setValue(true);
         SelfCriteriaMulti selfCriteriaMulti = new SelfCriteriaMulti();
-        selfCriteriaMulti.set_type(TypeMultiEnum.MULTI);
+        selfCriteriaMulti.setType(TypeMultiEnum.MULTI);
         selfCriteriaMulti.setCode("B001");
         selfCriteriaMulti.setDescription("Desc_Multi");
         List<String> values = new ArrayList<>();
@@ -782,7 +782,7 @@ class InitiativeModelToDTOMapperTest {
         values.add("valore2");
         selfCriteriaMulti.setValue(values);
         SelfCriteriaMultiConsent selfCriteriaMultiConsent = new SelfCriteriaMultiConsent();
-        selfCriteriaMultiConsent.set_type(TypeMultiConsentEnum.MULTI_CONSENT);
+        selfCriteriaMultiConsent.setType(TypeMultiConsentEnum.MULTI_CONSENT);
         selfCriteriaMultiConsent.setCode("ISEE");
         selfCriteriaMultiConsent.setDescription("Desc_Multi_Consent");
         selfCriteriaMultiConsent.setSubDescription("Sub_Desc_Multi_Consent");
@@ -791,7 +791,7 @@ class InitiativeModelToDTOMapperTest {
         selfCriteriaMultiConsentValueDTO.add(new SelfCriteriaMultiConsentValueDTO("description", "subDescription", "1"));
         selfCriteriaMultiConsent.setValue(selfCriteriaMultiConsentValueDTO);
         SelfCriteriaText selfCriteriaText = new SelfCriteriaText();
-        selfCriteriaText.set_type(TypeTextEnum.TEXT);
+        selfCriteriaText.setType(TypeTextEnum.TEXT);
         selfCriteriaText.setCode("T001");
         selfCriteriaText.setDescription("Text");
         selfCriteriaText.setValue("valore libero");

--- a/src/test/java/it/gov/pagopa/initiative/service/EmailNotificationServiceTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/service/EmailNotificationServiceTest.java
@@ -269,12 +269,12 @@ class EmailNotificationServiceTest {
     private InitiativeBeneficiaryRule createInitiativeBeneficiaryRule() {
         InitiativeBeneficiaryRule initiativeBeneficiaryRule = new InitiativeBeneficiaryRule();
         SelfCriteriaBool selfCriteriaBool = new SelfCriteriaBool();
-        selfCriteriaBool.set_type(TypeBoolEnum.BOOLEAN);
+        selfCriteriaBool.setType(TypeBoolEnum.BOOLEAN);
         selfCriteriaBool.setCode("B001");
         selfCriteriaBool.setDescription("Desc_bool");
         selfCriteriaBool.setValue(true);
         SelfCriteriaMulti selfCriteriaMulti = new SelfCriteriaMulti();
-        selfCriteriaMulti.set_type(TypeMultiEnum.MULTI);
+        selfCriteriaMulti.setType(TypeMultiEnum.MULTI);
         selfCriteriaMulti.setCode("B001");
         selfCriteriaMulti.setDescription("Desc_Multi");
         List<String> values = new ArrayList<>();

--- a/src/test/java/it/gov/pagopa/initiative/service/InitiativeServiceTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/service/InitiativeServiceTest.java
@@ -1898,12 +1898,12 @@ class InitiativeServiceTest {
     private InitiativeBeneficiaryRule createInitiativeBeneficiaryRule() {
         InitiativeBeneficiaryRule initiativeBeneficiaryRule = new InitiativeBeneficiaryRule();
         SelfCriteriaBool selfCriteriaBool = new SelfCriteriaBool();
-        selfCriteriaBool.set_type(TypeBoolEnum.BOOLEAN);
+        selfCriteriaBool.setType(TypeBoolEnum.BOOLEAN);
         selfCriteriaBool.setCode("B001");
         selfCriteriaBool.setDescription("Desc_bool");
         selfCriteriaBool.setValue(true);
         SelfCriteriaMulti selfCriteriaMulti = new SelfCriteriaMulti();
-        selfCriteriaMulti.set_type(TypeMultiEnum.MULTI);
+        selfCriteriaMulti.setType(TypeMultiEnum.MULTI);
         selfCriteriaMulti.setCode("B001");
         selfCriteriaMulti.setDescription("Desc_Multi");
         List<String> values = new ArrayList<>();

--- a/src/test/java/it/gov/pagopa/initiative/service/InitiativeValidationServiceTest.java
+++ b/src/test/java/it/gov/pagopa/initiative/service/InitiativeValidationServiceTest.java
@@ -726,12 +726,12 @@ class InitiativeValidationServiceTest {
     private InitiativeBeneficiaryRule createInitiativeBeneficiaryRule() {
         InitiativeBeneficiaryRule initiativeBeneficiaryRule = new InitiativeBeneficiaryRule();
         SelfCriteriaBool selfCriteriaBool = new SelfCriteriaBool();
-        selfCriteriaBool.set_type(TypeBoolEnum.BOOLEAN);
+        selfCriteriaBool.setType(TypeBoolEnum.BOOLEAN);
         selfCriteriaBool.setCode("B001");
         selfCriteriaBool.setDescription("Desc_bool");
         selfCriteriaBool.setValue(true);
         SelfCriteriaMulti selfCriteriaMulti = new SelfCriteriaMulti();
-        selfCriteriaMulti.set_type(TypeMultiEnum.MULTI);
+        selfCriteriaMulti.setType(TypeMultiEnum.MULTI);
         selfCriteriaMulti.setCode("B001");
         selfCriteriaMulti.setDescription("Desc_Multi");
         List<String> values = new ArrayList<>();
@@ -757,12 +757,12 @@ class InitiativeValidationServiceTest {
     private InitiativeBeneficiaryRule createInitiativeBeneficiaryRuleWithoutISEE() {
         InitiativeBeneficiaryRule initiativeBeneficiaryRule = new InitiativeBeneficiaryRule();
         SelfCriteriaBool selfCriteriaBool = new SelfCriteriaBool();
-        selfCriteriaBool.set_type(TypeBoolEnum.BOOLEAN);
+        selfCriteriaBool.setType(TypeBoolEnum.BOOLEAN);
         selfCriteriaBool.setCode("B001");
         selfCriteriaBool.setDescription("Desc_bool");
         selfCriteriaBool.setValue(true);
         SelfCriteriaMulti selfCriteriaMulti = new SelfCriteriaMulti();
-        selfCriteriaMulti.set_type(TypeMultiEnum.MULTI);
+        selfCriteriaMulti.setType(TypeMultiEnum.MULTI);
         selfCriteriaMulti.setCode("B001");
         selfCriteriaMulti.setDescription("Desc_Multi");
         List<String> values = new ArrayList<>();
@@ -788,12 +788,12 @@ class InitiativeValidationServiceTest {
     private InitiativeBeneficiaryRule createInitiativeBeneficiaryRule_EQ() {
         InitiativeBeneficiaryRule initiativeBeneficiaryRule = new InitiativeBeneficiaryRule();
         SelfCriteriaBool selfCriteriaBool = new SelfCriteriaBool();
-        selfCriteriaBool.set_type(TypeBoolEnum.BOOLEAN);
+        selfCriteriaBool.setType(TypeBoolEnum.BOOLEAN);
         selfCriteriaBool.setCode("B001");
         selfCriteriaBool.setDescription("Desc_bool");
         selfCriteriaBool.setValue(true);
         SelfCriteriaMulti selfCriteriaMulti = new SelfCriteriaMulti();
-        selfCriteriaMulti.set_type(TypeMultiEnum.MULTI);
+        selfCriteriaMulti.setType(TypeMultiEnum.MULTI);
         selfCriteriaMulti.setCode("B001");
         selfCriteriaMulti.setDescription("Desc_Multi");
         List<String> values = new ArrayList<>();


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
correct _type field typo after Java 25 upgrade

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- Pre-Deploy Test
    - [x] Unit
    - [x] Integration (Narrow)
- Post-Deploy Test
    - [x] Isolated Microservice
    - [ ] Broader Integration
    - [ ] Acceptance
    - [ ] Performance & Load

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] PATCH - Bug fix (backwards compatible bug fixes)
- [ ] MINOR - New feature (add functionality in a backwards compatible manner)
- [ ] MAJOR - Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.